### PR TITLE
Refactor schema output

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -809,23 +809,55 @@ func checkMetricsExtended(r io.Reader) ([]metricStat, int, error) {
 	return stats, total, nil
 }
 
-func schemaOverride(t reflect.Type) *jsonschema.Type {
-	durationType := reflect.TypeOf((*model.Duration)(nil)).Elem()
-	regexpType := reflect.TypeOf((*relabel.Regexp)(nil)).Elem()
-	yamlNodeType := reflect.TypeOf((*yaml.Node)(nil)).Elem()
-	// Special handling of map[string]string types so that they are evaluated correctly by json2jsii
-	// Specifically, we do this for Labels and Annotations in rule defs
-	if t.Kind() == reflect.Map && t.Key().Kind() == reflect.String {
+func handleMapString(t reflect.Type) *jsonschema.Type {
+	switch t.Elem().Kind() {
+	case reflect.Slice:
+		return &jsonschema.Type{
+			AdditionalProperties: []byte(`{ "type": "array", "items": { "type": "string" }}`),
+			Type:                 "object",
+		}
+	case reflect.String:
 		return &jsonschema.Type{
 			Type:                 "object",
 			AdditionalProperties: []byte(`{"type": "string"}`),
 		}
 	}
+	return nil
+}
+
+func schemaOverride(t reflect.Type) *jsonschema.Type {
+	durationType := reflect.TypeOf((*model.Duration)(nil)).Elem()
+	regexpType := reflect.TypeOf((*relabel.Regexp)(nil)).Elem()
+	yamlNodeType := reflect.TypeOf((*yaml.Node)(nil)).Elem()
+	labelList := reflect.TypeOf((*labels.Labels)(nil)).Elem()
+
 	if t == durationType || t == regexpType || t == yamlNodeType {
 		return &jsonschema.Type{
 			Type: "string",
 		}
 	}
+
+	// model/labels.Labels has special unmarshalling behavior that unmarshals a map of name:value pairs into a list of model/labels.Label structs
+	if t == labelList {
+		return &jsonschema.Type{
+			Type:                 "object",
+			AdditionalProperties: []byte(`{"type": "string"}`),
+		}
+	}
+
+	// Special handling of map[string]<something> types and slices of those types so that they are evaluated correctly by json2jsii
+	// Specifically, we do this for Labels and Annotations in rule defs,
+	// as well as some other places where map[string][]string isn't handled correctly
+	if t.Kind() == reflect.Map && t.Key().Kind() == reflect.String {
+		return handleMapString(t)
+	} else if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Map && t.Elem().Key().Kind() == reflect.String {
+		mapType := handleMapString(t.Elem())
+		return &jsonschema.Type{
+			Type:  "array",
+			Items: mapType,
+		}
+	}
+
 	return nil
 }
 
@@ -848,10 +880,13 @@ func schemaAddFields(t reflect.Type) []reflect.StructField {
 	if t == scrapeConfig || t == alertConfig {
 		return discovery.ConfigsAsFields()
 	}
+
+	// There is special marshalling behavior in the discovery/targetgroup package that
+	// converts a list of addresses from the inputted string into LabelName:LabelValue pairs using a hard coded LabelName
 	if t == group {
 		return []reflect.StructField{
 			{
-				Name: "Targets",
+				Name: "targets",
 				Type: reflect.TypeOf((*[]string)(nil)).Elem(),
 			},
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -516,7 +516,7 @@ type TSDBConfig struct {
 	// OutOfOrderTimeWindowFlag holds the parsed duration from the config file.
 	// During unmarshall, this is converted into milliseconds and stored in OutOfOrderTimeWindow.
 	// This should not be used directly and must be converted into OutOfOrderTimeWindow.
-	OutOfOrderTimeWindowFlag model.Duration `yaml:"out_of_order_time_window,omitempty"`
+	OutOfOrderTimeWindowFlag model.Duration `yaml:"out_of_order_time_window,omitempty" jsonschema:"-"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -123,7 +123,7 @@ func (c *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type SDConfig struct {
 	APIServer          config.URL              `yaml:"api_server,omitempty"`
 	Role               Role                    `yaml:"role"`
-	KubeConfig         string                  `yaml:"kubeconfig_file"`
+	KubeConfig         string                  `yaml:"kubeconfig_file,omitempty"`
 	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
 	NamespaceDiscovery NamespaceDiscovery      `yaml:"namespaces,omitempty"`
 	Selectors          []SelectorConfig        `yaml:"selectors,omitempty"`
@@ -249,7 +249,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // NamespaceDiscovery is the configuration for discovering
 // Kubernetes namespaces.
 type NamespaceDiscovery struct {
-	IncludeOwnNamespace bool     `yaml:"own_namespace"`
+	IncludeOwnNamespace bool     `yaml:"own_namespace,omitempty"`
 	Names               []string `yaml:"names"`
 }
 

--- a/discovery/targetgroup/targetgroup.go
+++ b/discovery/targetgroup/targetgroup.go
@@ -26,10 +26,10 @@ type Group struct {
 	// uniquely identifiable in the group by its address label.
 	Targets []model.LabelSet `jsonschema:"-"`
 	// Labels is a set of labels that is common across all targets in the group.
-	Labels model.LabelSet
+	Labels model.LabelSet `yaml:"labels,omitempty"`
 
 	// Source is an identifier that describes a group of targets.
-	Source string
+	Source string `yaml:"source,omitempty"`
 }
 
 func (tg Group) String() string {


### PR DESCRIPTION
This change has two major components:
- First, refactored handling of []map[string]foo and map[string]foo types. This correct several strange inconsistencies that the underlying jsonschema library would have used patternProperties with `.*` to handle.
- Second, individually correct several special-case struct fields due to custom unmarshalling logic within Prometheus.