### PR TITLE
Add schema post-processing to eliminate unnecessary fields

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prometheus/exporter-toolkit/web"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v3"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -894,6 +895,24 @@ func schemaAddFields(t reflect.Type) []reflect.StructField {
 	return nil
 }
 
+func removeRequiredFields(schema *apiextensionsv1.JSONSchemaProps) {
+	fieldsToDelete := make([]int, 0)
+	for i, val := range schema.Required {
+		// These fields are optional, and have defaults set,
+		// but are not tagged with omitempty by upstream to ensure their false values are unmarshalled clearly
+		if val == "follow_redirects" || val == "enable_http2" {
+			fieldsToDelete = append(fieldsToDelete, i)
+		}
+	}
+
+	// Ensure we iterate through the array backwards to prevent changing the index numbers
+	sort.Ints(fieldsToDelete)
+	for i := len(fieldsToDelete) - 1; i >= 0; i-- {
+		indexToDelete := fieldsToDelete[i]
+		schema.Required = append(schema.Required[:indexToDelete], schema.Required[indexToDelete+1:]...)
+	}
+}
+
 // OutputSchema renders a json schema for the given Type.
 func OutputSchema(t reflect.Type) int {
 	r := &jsonschema.Reflector{
@@ -903,10 +922,18 @@ func OutputSchema(t reflect.Type) int {
 		AdditionalFields:    schemaAddFields,
 	}
 	schema := r.ReflectFromType(t)
-	err := json.NewEncoder(os.Stdout).Encode(schema)
+	schemaBytes, err := json.Marshal(schema)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
 		return 1
 	}
+
+	parsedSchema, err := ParseSchemaFromBytes(schemaBytes, removeRequiredFields)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		return 1
+	}
+	fmt.Println(string(parsedSchema))
 	return 0
 }
 

--- a/cmd/promtool/parse.go
+++ b/cmd/promtool/parse.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+const maxRecursion = 500
+
+func ParseSchemaFromBytes(input []byte, visitor schemaVisitorFn) (reparsedSchemaBytes []byte, err error) {
+	var schema apiextensionsv1.JSONSchemaProps
+	err = json.Unmarshal(input, &schema)
+	if err != nil {
+		return nil, err
+	}
+
+	reparsedSchema, err := ParseSchema(schema, visitor)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(reparsedSchema)
+}
+
+func ParseSchema(schema apiextensionsv1.JSONSchemaProps, visitor schemaVisitorFn) (apiextensionsv1.JSONSchemaProps, error) {
+	schema.Schema = "http://json-schema.org/draft-04/schema#"
+
+	if visitor != nil {
+		visitSchema(&visitCtx{}, &schema, visitor)
+	}
+	return schema, nil
+}
+
+type schemaVisitorFn func(schema *apiextensionsv1.JSONSchemaProps)
+
+type visitCtx struct {
+	recursionLevel int
+}
+
+func visitSchema(ctx *visitCtx, schema *apiextensionsv1.JSONSchemaProps, visit schemaVisitorFn) {
+	ctx.recursionLevel++
+	if ctx.recursionLevel > maxRecursion {
+		return
+	}
+	defer func() { ctx.recursionLevel-- }()
+
+	visitSlice := func(props []apiextensionsv1.JSONSchemaProps) {
+		for i, s := range props {
+			s := s
+			visitSchema(ctx, &s, visit)
+			props[i] = s
+		}
+	}
+	visitMap := func(props map[string]apiextensionsv1.JSONSchemaProps) {
+		for k, s := range props {
+			s := s
+			visitSchema(ctx, &s, visit)
+			props[k] = s
+		}
+	}
+
+	if schema == nil {
+		return
+	}
+
+	// First visit the current schema props.
+	visit(schema)
+
+	visitSlice(schema.AllOf)
+	visitSlice(schema.OneOf)
+	visitSlice(schema.AnyOf)
+	visitSchema(ctx, schema.Not, visit)
+	visitMap(schema.Properties)
+	visitMap(schema.PatternProperties)
+	if schema.AdditionalProperties != nil {
+		visitSchema(ctx, schema.AdditionalProperties.Schema, visit)
+	}
+	if schema.AdditionalItems != nil {
+		visitSchema(ctx, schema.AdditionalItems.Schema, visit)
+	}
+
+	// Then recurse into child schema props.
+	if schema.Items != nil {
+		visitSchema(ctx, schema.Items.Schema, visit)
+		visitSlice(schema.Items.JSONSchemas)
+	}
+	if schema.Definitions != nil {
+		visitMap(schema.Definitions)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
 	github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99
+	k8s.io/apiextensions-apiserver v0.26.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1288,6 +1288,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/api v0.26.0/go.mod h1:k6HDTaIFC8yn1i6pSClSqIwLABIcLV9l5Q4EcngKnQg=
+k8s.io/apiextensions-apiserver v0.26.0 h1:Gy93Xo1eg2ZIkNX/8vy5xviVSxwQulsnUdQ00nEdpDo=
+k8s.io/apiextensions-apiserver v0.26.0/go.mod h1:7ez0LTiyW5nq3vADtK6C3kMESxadD51Bh6uz3JOlqWQ=
 k8s.io/apimachinery v0.26.0 h1:1feANjElT7MvPqp0JT6F3Ss6TWDwmcjLypwoPpEf7zg=
 k8s.io/apimachinery v0.26.0/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/client-go v0.26.0 h1:lT1D3OfO+wIi9UFolCrifbjUUgu7CpLca0AD8ghRLI8=


### PR DESCRIPTION
These fields have default values, but are not tagged with `omitempty` to prevent them from being skipped during unmarshalling when set to false